### PR TITLE
Adding whitespace/newline trimmers and `isort`

### DIFF
--- a/{{cookiecutter.package_name}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.package_name}}/.pre-commit-config.yaml
@@ -9,3 +9,14 @@ repos:
     hooks:
     - id: flake8
       pass_filenames: true
+# Sort order of Python imports
+-   repo: https://github.com/pycqa/isort
+    rev: 5.10.1
+    hooks:
+    - id: isort
+# Remove whitespace at line end, ensure newline at the end of files
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.3.0
+    hooks:
+    - id: trailing-whitespace
+    - id: end-of-file-fixer


### PR DESCRIPTION
I noticed `isort` was missing (you mentioned it in the [dev guidelines](https://hackmd.io/SbO3WyePSF-XEJVLZoX3og) with us. Perhaps/probably you're already on this.

Also, I propose adding [`trailing-whitespace`](https://github.com/pre-commit/pre-commit-hooks#trailing-whitespace) and [`end-of-file-fixer`](https://github.com/pre-commit/pre-commit-hooks#end-of-file-fixer) from the list of pre-cooked pre-commit pre-commit hooks. Which do what you'd imagine.

To quote a wise man:

> "It's like having the worlds pickiest python developer watching over your shoulder."