### PR TITLE
Replace isort with ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,8 +1,4 @@
 repos:
-    - repo: https://github.com/pycqa/isort
-      rev: 5.12.0
-      hooks:
-          - id: isort
     - repo: https://github.com/pre-commit/pre-commit-hooks
       rev: v4.4.0
       hooks:

--- a/README.md
+++ b/README.md
@@ -169,16 +169,15 @@ add_numbers(1, 2)
 Running `pre-commit install` will run set up [pre-commit hooks](https://pre-commit.com/) to ensure the code is
 formatted correctly. Currently, these are:
 * [black](https://black.readthedocs.io/en/stable/) for code structure formatting (maximum line length set to 79)
-* [flake8](https://flake8.pycqa.org/en/latest/) to enforce [PEP8](https://www.python.org/dev/peps/pep-0008/)
 * [mypy](https://mypy.readthedocs.io/en/stable/index.html) a static type checker
-* [isort](https://pycqa.github.io/isort/) sorts imports alphabetically
+* [ruff](https://github.com/charliermarsh/ruff) does a number of jobs, including enforcing PEP8 and sorting imports
 
 These will prevent code from being committed if any of these hooks fail. To run them individually:
 ```bash
 black ./
 flake8
 mypy
-isort
+ruff .
 ```
 
 You can also run `pre-commit` to run all of them before trying to commit.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,11 +20,8 @@ exclude = '''
 )
 '''
 
-[tool.isort]
-profile = "black"
-line_length = 79
-
-
 [tool.ruff]
 line-length = 79
 exclude = ["__init__.py","build",".eggs"]
+select = ["I", "E", "F"]
+fix = true

--- a/tests/test_cookiecutter.py
+++ b/tests/test_cookiecutter.py
@@ -122,7 +122,6 @@ class TestCookieCutter:
             "coverage",
             "tox",
             "black",
-            "isort",
             "mypy",
             "pre-commit",
             "ruff",

--- a/{{cookiecutter.package_name}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.package_name}}/.pre-commit-config.yaml
@@ -1,8 +1,4 @@
 repos:
-    - repo: https://github.com/pycqa/isort
-      rev: 5.12.0
-      hooks:
-          - id: isort
     - repo: https://github.com/pre-commit/pre-commit-hooks
       rev: v4.4.0
       hooks:

--- a/{{cookiecutter.package_name}}/pyproject.toml
+++ b/{{cookiecutter.package_name}}/pyproject.toml
@@ -54,16 +54,15 @@ user_support = "https://github.com/{{cookiecutter.github_username_or_organizatio
 
 [project.optional-dependencies]
 dev = [
-	"pytest",
-	"pytest-cov",
-	"coverage",
-	"tox",
-	"black",
-   	"isort",
-    "mypy",
-	"pre-commit",
-	"ruff",
- 	"setuptools_scm",
+  "pytest",
+  "pytest-cov",
+  "coverage",
+  "tox",
+  "black",
+  "mypy",
+  "pre-commit",
+  "ruff",
+  "setuptools_scm",
 ]
 
 
@@ -108,10 +107,6 @@ exclude = '''
 )
 '''
 
-[tool.isort]
-profile = "black"
-line_length = 79
-
 [tool.setuptools_scm]
 
 [tool.check-manifest]
@@ -128,3 +123,5 @@ ignore = [
 [tool.ruff]
 line-length = 79
 exclude = ["__init__.py","build",".eggs"]
+select = ["I", "E", "F"]
+fix = true


### PR DESCRIPTION
This replaces `isort` with `ruff`, by adding the "I" rule explicitly. I also turned out autofix, so running `pre-commit` will make fixes for you in some cases where `ruff` complains (including sorting imports).