### PR TITLE
Remove black excludes config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,16 +5,8 @@ line-length = 79
 exclude = '''
 (
   /(
-      \.eggs
-    | \.git
-    | \.hg
-    | \.mypy_cache
-    | \.tox
-    | \.venv
     | _build
     | buck-out
-    | build
-    | dist
     | examples
   )/
 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,15 +2,6 @@
 target-version = ['py38', 'py39', 'py310']
 skip-string-normalization = false
 line-length = 79
-exclude = '''
-(
-  /(
-    | _build
-    | buck-out
-    | examples
-  )/
-)
-'''
 
 [tool.isort]
 profile = "black"

--- a/{{cookiecutter.package_name}}/pyproject.toml
+++ b/{{cookiecutter.package_name}}/pyproject.toml
@@ -90,15 +90,6 @@ addopts = "--cov={{cookiecutter.module_name}}"
 target-version = ['py38', 'py39', 'py310']
 skip-string-normalization = false
 line-length = 79
-exclude = '''
-(
-  /(
-    | _build
-    | buck-out
-    | examples
-  )/
-)
-'''
 
 [tool.isort]
 profile = "black"

--- a/{{cookiecutter.package_name}}/pyproject.toml
+++ b/{{cookiecutter.package_name}}/pyproject.toml
@@ -93,16 +93,8 @@ line-length = 79
 exclude = '''
 (
   /(
-      \.eggs
-    | \.git
-    | \.hg
-    | \.mypy_cache
-    | \.tox
-    | \.venv
     | _build
     | buck-out
-    | build
-    | dist
     | examples
   )/
 )


### PR DESCRIPTION
[`black` automatically ignores files already specified in `.gitignore`](https://black.readthedocs.io/en/stable/usage_and_configuration/file_collection_and_discovery.html#gitignore), so remove files that are duplicated across `.gitignore` and the black config.

The remaining entries were
```toml
exclude = '''
(
  /(
    | _build
    | buck-out
    | examples
  )/
)
'''
```

and I these should either be in `.gitignore` (`_build`), not be ignored by black (`examples`) or I don't know what they are (`buck-out`), so I've just removed the exclude config completely. 