### PR TITLE
Add cibuildwheel config

### DIFF
--- a/{{cookiecutter.package_name}}/pyproject.toml
+++ b/{{cookiecutter.package_name}}/pyproject.toml
@@ -66,8 +66,6 @@ dev = [
  	"setuptools_scm",
 ]
 
-
-
 [build-system]
 requires = [
     "setuptools>=45",
@@ -128,3 +126,9 @@ ignore = [
 [tool.ruff]
 line-length = 79
 exclude = ["__init__.py","build",".eggs"]
+
+[tool.cibuildwheel]
+build = "cp38-* cp39-* cp310-*"
+
+[tool.cibuildwheel.macos]
+archs = ["x86_64", "arm64"]


### PR DESCRIPTION
This adds `cibuildwheel` configuration, in particular to:

- Limit Python versions that are being used to those that are used for testing
- Build wheels for macOS arm64, which needs to be manually specified.