### PR TITLE
Test rewrite

### DIFF
--- a/tests/test_cookiecutter.py
+++ b/tests/test_cookiecutter.py
@@ -1,7 +1,7 @@
 import os
+import platform
 import subprocess
 from pathlib import Path
-import platform
 
 import pytest
 import toml
@@ -12,7 +12,6 @@ import yaml
 # cookiecutter
 # pytest
 # toml
-
 
 COOKIECUTTER_DIR = Path(__file__).parent.parent
 CONFIG_FILENAME = COOKIECUTTER_DIR / "tests" / "cookiecutter_test_configs.yaml"

--- a/tests/test_cookiecutter.py
+++ b/tests/test_cookiecutter.py
@@ -40,12 +40,15 @@ def package_path(tmp_path_factory):
 
 @pytest.fixture(autouse=True, scope="session")
 def pip_install(package_path):
+    uninstall_cmd = f"pip uninstall -y {config_dict['package_name']}"
+    dev_formatting = ".[dev]" if platform.system() == "Windows" else "'.[dev]'"
+    install_cmd = f"pip install -e {dev_formatting}"
+
     # Installs the package using pip
     os.chdir(package_path)
-
     # Uninstall and check package not installed
     subprocess.run("git init", shell=True)
-    uninstall_cmd = f"pip uninstall -y {config_dict['package_name']}"
+
     subprocess.run(uninstall_cmd, shell=True)
     result = subprocess.Popen(
         f"pip show {config_dict['package_name']}",
@@ -59,12 +62,8 @@ def pip_install(package_path):
     )
 
     # Install package
-    dev_formatting = ".[dev]" if platform.system() == "Windows" else "'.[dev]'"
-    cmd = f"pip install -e {dev_formatting}"
-    result = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE)
-    stdout, __ = result.communicate()
+    subprocess.run(install_cmd, shell=True)
     yield
-
     # Uninstall package
     subprocess.run(uninstall_cmd, shell=True)
 

--- a/tests/test_cookiecutter.py
+++ b/tests/test_cookiecutter.py
@@ -1,6 +1,7 @@
 import os
 import subprocess
 from pathlib import Path
+import platform
 
 import pytest
 import toml
@@ -59,7 +60,8 @@ def pip_install(package_path):
     )
 
     # Install package
-    cmd = "pip install -e '.[dev]'"
+    dev_formatting = ".[dev]" if platform.system() == "Windows" else "'[.dev]'"
+    cmd = f"pip install -e {dev_formatting}"
     result = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE)
     stdout, __ = result.communicate()
     yield

--- a/tests/test_cookiecutter.py
+++ b/tests/test_cookiecutter.py
@@ -152,7 +152,6 @@ def test_pyproject_toml(package_path):
         "coverage",
         "tox",
         "black",
-        "isort",
         "mypy",
         "pre-commit",
         "ruff",

--- a/tests/test_cookiecutter.py
+++ b/tests/test_cookiecutter.py
@@ -69,21 +69,25 @@ def pip_install(package_path):
 
 
 def test_directory_names(package_path):
-
     assert package_path.exists()
-    assert (package_path / ".github").exists()
-    assert (package_path / ".gitignore").exists()
-    assert (package_path / ".pre-commit-config.yaml").exists()
-    assert (package_path / "LICENSE").exists()
-    assert (package_path / "MANIFEST.in").exists()
-    assert (package_path / "pyproject.toml").exists()
-    assert (package_path / "README.md").exists()
-    assert (package_path / "tox.ini").exists()
+    expected = [
+        # Files
+        ".github",
+        ".gitignore",
+        ".pre-commit-config.yaml",
+        "LICENSE",
+        "MANIFEST.in",
+        "pyproject.toml",
+        "README.md",
+        "tox.ini",
+        Path("test_cookiecutter") / "__init__.py",
+        # Directories
+        "test_cookiecutter",
+        "tests",
+    ]
 
-    assert (package_path / "test_cookiecutter").exists()
-    assert (package_path / "test_cookiecutter" / "__init__.py").exists()
-
-    assert (package_path / "tests").exists()
+    for f in expected:
+        assert (package_path / f).exists()
 
 
 def test_pyproject_toml(package_path):

--- a/tests/test_cookiecutter.py
+++ b/tests/test_cookiecutter.py
@@ -59,7 +59,7 @@ def pip_install(package_path):
     )
 
     # Install package
-    dev_formatting = ".[dev]" if platform.system() == "Windows" else "'[.dev]'"
+    dev_formatting = ".[dev]" if platform.system() == "Windows" else "'.[dev]'"
     cmd = f"pip install -e {dev_formatting}"
     result = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE)
     stdout, __ = result.communicate()


### PR DESCRIPTION
This cleans up the test, with the following goals:

- Move the tests into individual `test_` functions, instead of running them at the bottom of the file.
- Use pytest fixtures to setup the package in a temporary directory, and then pip install the package.
- Use a pytest fixture that yields to automatically pip uninstall the package once testing is finished.

This ended up being a bit of a re-write - sorry for the large diff! But this should make it a lot easier to extend the tests in the future. If anything doesn't make sense please let me know!